### PR TITLE
Update to support writing to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Cake.Handlebars
+
+## A simple Cake addin for rendering and compiling Handlebars templates
+
+## Installation
+
+In your build script, add the following directive to install Cake.Handlebars:
+
+```cake
+#addin nuget:?package=Cake.Handlebars
+```
+
+## Usage
+
+This addin exposes four aliases for rendering and compiling, from either `string` or input file.
+
+```csharp
+var result = RenderTemplate("Hello {{ name }}!", new { name = "World"});
+result = RenderTemplateFromFile("./template.hbs", new { name = "World"});
+```
+
+```csharp
+var compiled = CompileTemplate("Hello {{ name}}!");
+var result = compiled(new { name = "World"});
+
+var template = CompileTemplateFromFile("./template.hbs");
+result = template(new { name = "World"});
+```
+
+### Writing to file
+
+While the above examples will work anywhere you want the `string` output, you can also write directly to a file using the fluent `WriteToFile` method:
+
+```csharp
+RenderTemplate("Hello {{ name }}!", new { name = "World"}).WriteToFile("./output.txt");
+```
+
+```csharp
+var compiled = CompileTemplate("Hello {{ name}}!");
+var result = compiled(new { name = "World"}).WriteToFile("./output.txt");
+```

--- a/build.cake
+++ b/build.cake
@@ -10,7 +10,7 @@
 var target = Argument<string>("target", "Default");
 var configuration = Argument<string>("configuration", "Release");
 var fallbackVersion = Argument<string>("force-version", EnvironmentVariable("FALLBACK_VERSION") ?? "0.1.0");
-var buildFrameworks = Argument("frameworks", "netstandard1.6;net46");
+var buildFrameworks = Argument("frameworks", "netstandard2.0;net46");
 
 ///////////////////////////////////////////////////////////////////////////////
 // VERSIONING

--- a/src/Cake.Handlebars/Cake.Handlebars.csproj
+++ b/src/Cake.Handlebars/Cake.Handlebars.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.24.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.1" />
     <PackageReference Include="Handlebars.Net" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Handlebars/HandlebarsAliases.cs
+++ b/src/Cake.Handlebars/HandlebarsAliases.cs
@@ -13,30 +13,32 @@ namespace Cake.Handlebars
     public static class HandlebarsAliases
     {
         [CakeMethodAlias]
-        public static string RenderTemplate(this ICakeContext ctx, string template, object data) {
+        public static RenderResult RenderTemplate(this ICakeContext ctx, string template, object data) {
             ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
             var compiled = Hbs.Compile(template);
-            return compiled(data);
+            return new RenderResult(ctx, compiled(data));
         }
 
         [CakeMethodAlias]
-        public static string RenderTemplateFromFile(this ICakeContext ctx, FilePath templateFilePath, object data) {
+        public static RenderResult RenderTemplateFromFile(this ICakeContext ctx, FilePath templateFilePath, object data) {
             ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
             var file = new TemplateFileReader(ctx.FileSystem, templateFilePath);
-            return file.RenderTemplate(data);
+            return new RenderResult(ctx, file.RenderTemplate(data));
         }
 
         [CakeMethodAlias]
-        public static Func<object, string> CompileTemplate(this ICakeContext ctx, string template) {
+        public static Func<object, RenderResult> CompileTemplate(this ICakeContext ctx, string template) {
             ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
-            return Hbs.Compile(template);
+            return RenderResult.FromCompiledTemplate(ctx, Hbs.Compile(template));
         }
 
         [CakeMethodAlias]
-        public static Func<object, string> CompileTemplateFromFile(this ICakeContext ctx, FilePath templateFilePath) {
+        public static Func<object, RenderResult> CompileTemplateFromFile(this ICakeContext ctx, FilePath templateFilePath) {
             ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
             var file = new TemplateFileReader(ctx.FileSystem, templateFilePath);
-            return file.CompileTemplate();
+            return RenderResult.FromCompiledTemplate(ctx, file.CompileTemplate());
         }
+
+        
     }
 }

--- a/src/Cake.Handlebars/RenderResult.cs
+++ b/src/Cake.Handlebars/RenderResult.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Handlebars
+{
+    public class RenderResult 
+    {
+        private ICakeContext Context {get;}
+        private string Content {get;set;}
+        internal RenderResult(ICakeContext ctx, string content)
+        {
+            Context = ctx;
+            Content = content;
+        }
+
+        public static implicit operator string(RenderResult result) {
+            return result.Content;
+        }
+
+        public override string ToString() {
+            return Content;
+        }
+        
+        internal static Func<object, RenderResult> FromCompiledTemplate(ICakeContext ctx, Func<object, string> compiled) {
+            return data => new RenderResult(ctx, compiled(data));
+        }
+
+        public RenderResult WriteToFile(FilePath targetPath) {
+            using (var writer = new StreamWriter(Context.FileSystem.GetFile(targetPath).OpenWrite())) {
+                writer.Write(Content);
+            }
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This changes the API surface to introduce a new `RenderResult` type.

With the `operator` in place, this should require no changes to scripts, but now allows for `WriteToFile` to write template output to files without a new alias.

Thoughts @gep13 @thzinc ?
